### PR TITLE
Feature/fix parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in releasecreator.
 
 ## Unreleased
 
+- Fixed an issue where the parser would take any `##` combination, it will now look for a new line before it
+
 ## 1.1.0 - *2020-10-25*
 
 - Validate the HMAC signature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in releasecreator.
 - Fixed an issue where the parser would take any `##` combination
   - it will now look for a new line before it
   - It must end with a version number of d+.d+.d+
+- If there is no other entries it will now match on end of file.
 
 ## 1.1.0 - *2020-10-25*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This file is used to list changes made in releasecreator.
 
 ## Unreleased
 
-- Fixed an issue where the parser would take any `##` combination, it will now look for a new line before it
+- Fixed an issue where the parser would take any `##` combination
+  - it will now look for a new line before it
+  - It must end with a version number of d+.d+.d+
 
 ## 1.1.0 - *2020-10-25*
 

--- a/lib/releasecreator/vcs.rb
+++ b/lib/releasecreator/vcs.rb
@@ -25,7 +25,7 @@ module ReleaseCreator
 
     def unreleased_changelog_entry
       content = get_file_contents(@changelog_name)['content']
-      result = /##\s+(Unreleased)([\s\S]*?)##/im.match(content)
+      result = /##\s+(Unreleased)([\s\S]*?)\n##/im.match(content)
       return result[2].strip if result
 
       nil

--- a/lib/releasecreator/vcs.rb
+++ b/lib/releasecreator/vcs.rb
@@ -25,7 +25,7 @@ module ReleaseCreator
 
     def unreleased_changelog_entry
       content = get_file_contents(@changelog_name)['content']
-      result = /##\s+(Unreleased)([\s\S]*?)\n##/im.match(content)
+      result = /##\s+(Unreleased)([\s\S]*?)\n##\s+\d+\.\d+\.\d+/im.match(content)
       return result[2].strip if result
 
       nil

--- a/lib/releasecreator/vcs.rb
+++ b/lib/releasecreator/vcs.rb
@@ -25,7 +25,7 @@ module ReleaseCreator
 
     def unreleased_changelog_entry
       content = get_file_contents(@changelog_name)['content']
-      result = /##\s+(Unreleased)([\s\S]*?)\n##\s+\d+\.\d+\.\d+/im.match(content)
+      result = /##\s+(Unreleased)([\s\S]*?)(\n##\s+\d+\.\d+\.\d+|\Z)/im.match(content)
       return result[2].strip if result
 
       nil


### PR DESCRIPTION
# Description

- Fixed an issue where the parser would take any `##` combination
  - it will now look for a new line before it
  - It must end with a version number of d+.d+.d+
- If there is no other entries it will now match on end of file.

## Issues Resolved

[List any existing issues this PR resolves]

## Check List

- [ ] All tests pass
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the CHANGELOG
- [ ] New functionality has been documented in the README if applicable
